### PR TITLE
Use GHC 8.8.3

### DIFF
--- a/{{cookiecutter.project_name}}/default.nix
+++ b/{{cookiecutter.project_name}}/default.nix
@@ -1,4 +1,4 @@
-{ compiler ? "ghc865" }:
+{ compiler ? "ghc883" }:
 
 let
   sources = import ./nix/sources.nix;


### PR DESCRIPTION
I don't see a reason why not.

I also tried GHC 8.10, but "constraints" does not compile there, which is a transitive dependency of some of our packages (probably hedgehog).