### PR TITLE
Update to GHC 8.10.1

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -6,6 +6,7 @@ rec {
 
   generated = pkgs.runCommand "hs-nix-template" {
     buildInputs = [ pkgs.cookiecutter ];
+    preferLocalBuild = true;
   } ''
     HOME="$(mktemp -d)"
     mkdir "$out"

--- a/{{cookiecutter.project_name}}/default.nix
+++ b/{{cookiecutter.project_name}}/default.nix
@@ -1,4 +1,4 @@
-{ compiler ? "ghc883" }:
+{ compiler ? "ghc8101" }:
 
 let
   sources = import ./nix/sources.nix;

--- a/{{cookiecutter.project_name}}/nix/sources.json
+++ b/{{cookiecutter.project_name}}/nix/sources.json
@@ -12,15 +12,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
-        "branch": "nixos-20.03",
+        "branch": "nixpkgs-unstable",
         "description": "Nix Packages collection",
         "homepage": null,
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "182f229ba7cc197768488972347e47044cd793fb",
-        "sha256": "0x20m7czzyla2rd9vyn837wyc2hjnpad45idq823ixmdhyifx31s",
+        "rev": "8fc744839bdc6a23e37f6de9f67bd4916839acc9",
+        "sha256": "1khq4vimadhk5wqh6092pdfld8830a1lmd4nqr9ss4i2z99hr1x6",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/182f229ba7cc197768488972347e47044cd793fb.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/8fc744839bdc6a23e37f6de9f67bd4916839acc9.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
Also start tracking `nixpkgs-unstable` branch. It seems to have more
of cache hits, and provides more up-to-date packages.