### PR TITLE
Add project_configuration_tool option to template

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,8 @@ cabal build
 ```
 
 The nix shell will contain `hpack` for local development and the nix build will
-automatically handle changes to package.yaml. See [hpack-docs](the hpack
-documentation) for more information.
-
-[hpack-docs]: https://github.com/sol/hpack#hpack-a-modern-format-for-haskell-packages
+automatically handle changes to package.yaml. See [the hpack
+documentation](https://github.com/sol/hpack#hpack-a-modern-format-for-haskell-packages) for more information.
 
 ### Run Hoogle locally
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,23 @@ docker load -i result
 
 ## Cheat Sheet
 
+### Use the hpack configuration tool
+
+When running cookiecutter, you'll be presented with the option of using cabal's
+default configuration format or hpack. When using hpack, you will need to run
+hpack to generate a cabal file before building, i.e.
+
+```sh
+hpack .
+cabal build
+```
+
+The nix shell will contain `hpack` for local development and the nix build will
+automatically handle changes to package.yaml. See [hpack-docs](the hpack
+documentation) for more information.
+
+[hpack-docs]: https://github.com/sol/hpack#hpack-a-modern-format-for-haskell-packages
+
 ### Run Hoogle locally
 
 - `hoogle server --local -p 3000 -n`

--- a/ci.nix
+++ b/ci.nix
@@ -22,7 +22,7 @@ rec {
   } ''
     HOME="$(mktemp -d)"
     mkdir "$out"
-    cookiecutter --no-input --output-dir "$out" ${./.} use_hpack=y
+    cookiecutter --no-input --output-dir "$out" ${./.} project_configuration_tool="package.yaml (hpack)"
   '';
 
   buildWithHpack = pkgs.recurseIntoAttrs

--- a/ci.nix
+++ b/ci.nix
@@ -15,4 +15,16 @@ rec {
 
   build = pkgs.recurseIntoAttrs
     (import "${generated}/your-project-name" {});
+
+  generatedWithHpack = pkgs.runCommand "hs-nix-template" {
+    buildInputs = [ pkgs.cookiecutter ];
+    preferLocalBuild = true;
+  } ''
+    HOME="$(mktemp -d)"
+    mkdir "$out"
+    cookiecutter --no-input --output-dir "$out" ${./.} use_hpack=y
+  '';
+
+  buildWithHpack = pkgs.recurseIntoAttrs
+    (import "${generatedWithHpack}/your-project-name" {});
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -4,5 +4,6 @@
   "category": "Package.Category",
   "module": "{{cookiecutter.project_name|title|replace('-', '')}}",
   "author_name": "Your Name",
-  "gh_user": "your_github_username"
+  "gh_user": "your_github_username",
+  "use_hpack": "n"
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -5,5 +5,5 @@
   "module": "{{cookiecutter.project_name|title|replace('-', '')}}",
   "author_name": "Your Name",
   "gh_user": "your_github_username",
-  "use_hpack": "n"
+  "project_configuration_tool": ["{{cookiecutter.project_name|replace('-', '')}}.cabal (cabal's default)", "package.yaml (hpack)"]
 }

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,0 +1,15 @@
+import os
+import sys
+
+REMOVE_PATHS = [
+    '{% if cookiecutter.use_hpack == "y" %} {{ cookiecutter.project_name }}.cabal {% endif %}',
+    '{% if cookiecutter.use_hpack != "y" %} package.yaml {% endif %}',
+]
+
+for path in REMOVE_PATHS:
+    path = path.strip()
+    if path and os.path.exists(path):
+        if os.path.isdir(path):
+            os.rmdir(path)
+        else:
+            os.unlink(path)

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -2,8 +2,8 @@ import os
 import sys
 
 REMOVE_PATHS = [
-    '{% if cookiecutter.use_hpack == "y" %} {{ cookiecutter.project_name }}.cabal {% endif %}',
-    '{% if cookiecutter.use_hpack != "y" %} package.yaml {% endif %}',
+    '{% if cookiecutter.project_configuration_tool.startswith("package.yaml") %} {{ cookiecutter.project_name }}.cabal {% endif %}',
+    '{% if not cookiecutter.project_configuration_tool.startswith("package.yaml") %} package.yaml {% endif %}',
 ]
 
 for path in REMOVE_PATHS:

--- a/{{cookiecutter.project_name}}/default.nix
+++ b/{{cookiecutter.project_name}}/default.nix
@@ -26,6 +26,7 @@ let
       pkgs.haskellPackages.ghcid
       pkgs.haskellPackages.ormolu
       pkgs.haskellPackages.hlint
+      {% if cookiecutter.use_hpack == "y" %}pkgs.haskellPackages.hpack{% endif %}
       pkgs.niv
       pkgs.nixpkgs-fmt
     ];

--- a/{{cookiecutter.project_name}}/default.nix
+++ b/{{cookiecutter.project_name}}/default.nix
@@ -26,8 +26,7 @@ let
       pkgs.haskellPackages.ghcid
       pkgs.haskellPackages.ormolu
       pkgs.haskellPackages.hlint
-      {% if cookiecutter.project_configuration_tool.startswith("package.yaml") %}
-      pkgs.haskellPackages.hpack
+      {% if cookiecutter.project_configuration_tool.startswith("package.yaml") %}pkgs.haskellPackages.hpack
       {% endif -%}
       pkgs.niv
       pkgs.nixpkgs-fmt

--- a/{{cookiecutter.project_name}}/default.nix
+++ b/{{cookiecutter.project_name}}/default.nix
@@ -26,7 +26,9 @@ let
       pkgs.haskellPackages.ghcid
       pkgs.haskellPackages.ormolu
       pkgs.haskellPackages.hlint
-      {% if cookiecutter.use_hpack == "y" %}pkgs.haskellPackages.hpack{% endif %}
+      {% if cookiecutter.project_configuration_tool.startswith("package.yaml") %}
+      pkgs.haskellPackages.hpack
+      {% endif -%}
       pkgs.niv
       pkgs.nixpkgs-fmt
     ];

--- a/{{cookiecutter.project_name}}/package.yaml
+++ b/{{cookiecutter.project_name}}/package.yaml
@@ -1,0 +1,32 @@
+name: {{cookiecutter.project_name}}
+version: 0.0.1.0
+synopsis: {{cookiecutter.project_synopsis}}
+description: See README at <https://github.com/{{cookiecutter.gh_user}}/{{cookiecutter.project_name}}
+author: {{cookiecutter.author_name}}
+github: {{cookiecutter.gh_user}}/{{cookiecutter.project_name}}
+category: {{cookiecutter.category}}
+license: BSD-3-Clause
+
+dependencies:
+  - base >=4.11 && < 5
+
+library:
+  source-dirs: src
+
+executables:
+  {{cookiecutter.project_name}}-exe:
+    source-dirs: app
+    main: Main.hs
+    dependencies:
+      - {{cookiecutter.project_name}}
+
+tests:
+  {{cookiecutter.project_name}}-test:
+    source-dirs: test
+    main: Main.hs
+    ghc-options:
+      - -Wall
+      - -threaded
+    dependencies:
+      - {{cookiecutter.project_name}}
+      - hedgehog


### PR DESCRIPTION
Closes #20 

- Add an option `project_configuration_tool` which writes `package.yaml` instead of `your-project-name.cabal`
- Added an additional CI step which overrides the default `project_configuration_tool` to hpack to test all configuration options
- I used `stack new example-project` to approximate a minimal `package.yaml` file with the changes you made in the cabal template