### PR TITLE
[#25] Add step name and update run command to be multiline

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,4 +16,8 @@ jobs:
       with:
         name: hs-nix-template
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
-    - run: nix-build ci.nix --argstr use_hpack "${{ matrix.use_hpack }}" --argstr add_executable_section "${{ matrix.add_executable_section }}"
+    - name: hs-nix-template
+      run: |
+        nix-build ci.nix \
+        --argstr use_hpack "${{ matrix.use_hpack }}" \
+        --argstr add_executable_section "${{ matrix.add_executable_section }}"


### PR DESCRIPTION
Hi! 

I happened to come across this issue and having done this once before I thought I could help. 

And that time I had a `name` key under steps and a multiline run with the pipe went under it, like so: https://github.com/dalpd/gram/commit/45ec11fe7ae87b5ca40ee521356633d36cc71500